### PR TITLE
Corrupted BSON output when saving documents containing arrays

### DIFF
--- a/bsonDoc.pas
+++ b/bsonDoc.pas
@@ -898,7 +898,7 @@ begin
       i:=0;
       stmWrite(@i,1);
       //write total length
-      OleCheck(stm.Seek(vstack[vindex].vstart,soFromBeginning,lx));
+      OleCheck(stm.Seek(lstart+vstack[vindex].vstart,soFromBeginning,lx));
       i:=ltotal-vstack[vindex].vstart;
       OleCheck(stm.Write(@i,4,@li));
       //return to end position


### PR DESCRIPTION
Hi,

I found a bug which corrupted the BSON output of a document containing an array.

The code didn't take in account the start of the BSON document when writing the size of the array, I fixed it in the including commit and now the documents are getting saved.

Regards,

Fred Oranje
