### PR TITLE
Added ping command to TMongoWire

### DIFF
--- a/mongoWire.pas
+++ b/mongoWire.pas
@@ -60,6 +60,7 @@ type
       Selector:IBSONDocument;
       SingleRemove:boolean=false
     );
+    function Ping: Boolean;
   end;
 
   TMongoWireQuery=class(TBSONDocumentsEnumerator)
@@ -466,6 +467,15 @@ begin
     CloseMsg;
   finally
     FWriteLock.Leave;
+  end;
+end;
+
+function TMongoWire.Ping: Boolean;
+begin
+  try
+    Result := Get('admin.$cmd', BSON(['ping', 1]))['ok'] = 1;
+  except
+    Result := False;
   end;
 end;
 


### PR DESCRIPTION
Hi,

In my search for checking if the MongoDB connection is still alive I added the ping command which I found inside the Ruby driver documentation (http://api.mongodb.org/ruby/current/Mongo/Connection.html).

It is a command which returns even if the server is in lock. I chose to handle any exceptions TMongoWire throws inside the method, so it returns false in those cases.

Kind regards,

Fred Oranje
