### PR TITLE
Added ensureIndex

### DIFF
--- a/mongoWire.pas
+++ b/mongoWire.pas
@@ -61,6 +61,11 @@ type
       SingleRemove:boolean=false
     );
     function Ping: Boolean;
+    procedure EnsureIndex(
+      Database,Collection:WideString;
+      Index:IBSONDocument;
+      Options:IBSONDocument=nil
+    );
   end;
 
   TMongoWireQuery=class(TBSONDocumentsEnumerator)
@@ -100,6 +105,8 @@ const
   mongoWire_QueryFlag_NoCursorTimeout = $0010;
   mongoWire_QueryFlag_AwaitData       = $0020;
   mongoWire_QueryFlag_Exhaust         = $0040;
+
+  mongoWire_Db_SystemIndexCollection = 'system.indexes';
 
 implementation
 
@@ -477,6 +484,48 @@ begin
   except
     Result := False;
   end;
+end;
+
+procedure TMongoWire.EnsureIndex(Database,Collection:WideString;
+  Index:IBSONDocument;Options:IBSONDocument=nil);
+var
+  Document: IBSONDocument;
+  Name: String;
+  I: Integer;
+  IndexArray: Variant;
+begin
+  Document := BSON([
+    'ns', Database + '.' + Collection,
+    'key', Index
+  ]);
+  
+  if (Options = nil) or (Options['name'] = Null) then begin
+    Name := '';
+    IndexArray := Index.ToVarArray;
+    for I := VarArrayLowBound(IndexArray, 1) to VarArrayHighBound(IndexArray, 1) do
+      Name := Name + VarToStr(VarArrayGet(IndexArray, [I, 0])) + '_' + VarToStr(VarArrayGet(IndexArray, [I, 1]));
+
+    if Length(Database + '.' + Collection + '.' + Name) > 128 then
+      raise Exception.Create('Index name too long, please specify a custom name using the name option.');
+
+    Document['name'] := Name;
+  end else
+    Document['name'] := Options['name'];
+
+  if Options <> nil then begin
+    if Options['background'] <> Null then
+      Document['background'] := Options['background'];
+    if Options['dropDups'] <> Null then
+      Document['dropDups'] := Options['dropDups'];
+    if Options['sparse'] <> Null then
+      Document['sparse'] := Options['sparse'];
+    if Options['unique'] <> Null then
+      Document['unique'] := Options['unique'];
+    if Options['v'] <> Null then
+      Document['v'] := Options['v'];
+  end;
+
+  Insert(Database + '.' + mongoWire_Db_SystemIndexCollection, Document);
 end;
 
 { TMongoWireQuery }


### PR DESCRIPTION
Hi,

I needed to create indexes from my application so I implemented the ensureIndex method. 

Kind regards,

Fred Oranje
## Usage

```
Wire.ensureIndex('database', 'collection', BSON(['name', 1]), BSON(['unique', true]));
```
## Choices
### Options as IBSONDocument

Allows you to specify the options which you need and keeps the databases defaults values when you don't specify them. 
### Name generation

The [MongoDB wiki](http://www.mongodb.org/display/DOCS/Indexes) contains the following text about creating indexes.

> name is also an option but need not be specified and will be deprecated in the future. The name of an index is generated by concatenating the names of the indexed fields and their direction (i.e., 1 or -1 for ascending or descending). Index names (including their namespace/database), are limited to 128 characters.

Initially I tried adding an index without specifying the name, but the index wouldn't insert. So I guess the text about the deprecated name option is written for the Mongo Shell. I added index name generation based on the results of the shell and I also check for the maximum length (including namespace/database) as described above.

I also made the choice to be able to specify your own name in case you want a different index name, or the generated one it too long. 
