### PR TITLE
Small fix for setting previously unset keys in the new Set_item method.

### DIFF
--- a/bsonDoc.pas
+++ b/bsonDoc.pas
@@ -207,6 +207,7 @@ begin
     for i:=FElementIndex-1 downto FGotSorted do FSorted[i+1]:=FSorted[i];//Move?
     FSorted[FGotSorted]:=FElementIndex;
     FElements[FElementIndex].Key:=Key;
+    FGotIndex:=FElementIndex;
     inc(FElementIndex);
    end;
   FElements[FGotIndex].Value:=Value;


### PR DESCRIPTION
Hi,

Your new code regarding keeping the original order of the keys contained a small bug which scrambles the BSONDocument when setting keys which we're new to the document.

I've added a small fix to solve the problem.

Kind regards,

Fred Oranje
